### PR TITLE
Add reflectance panel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 __pycache__/
+.vscode
 
 *.egg*
 *.pyc

--- a/corrections/detect_panel.py
+++ b/corrections/detect_panel.py
@@ -1,0 +1,119 @@
+import cv2 as cv
+import numpy as np
+import glob
+
+from PIL import Image
+
+# Constants
+MAX_VAL_12BIT = 4096
+
+ARUCO_SIDE_LENGTH_M = 0.07
+ARUCO_TOP_TO_PANEL_CENTER_M = 0.06
+
+SAMPLE_RECT_HEIGHT = 0.04
+SAMPLE_RECT_WIDTH = 0.04
+
+
+def convert_to_type(image, desired_type=np.uint8):
+    """
+    Converts the 12-bit tiff from a 6X sensor to a numpy compatible form
+    :param desired_type: The desired type
+    :return: The converted image in numpy.array format
+    """
+    image = image / MAX_VAL_12BIT # Scale to 0-1
+    image = np.iinfo(desired_type).max * image # Scale back to desired type
+    return image.astype(desired_type)
+
+def generate_aruco_marker(id=13):
+    """
+    Generates and writes to disk an aruco label
+    :param id: The aruco id of a 6x6 block, 250x250 pixel dictionary, defaults 13
+    :return: True/False
+    """
+    if (id >= 0 and id <=50):
+        dictionary = cv.aruco.Dictionary_get(cv.aruco.DICT_6X6_250)
+        cv.aruco.drawMarker(dictionary, id, 200, markerImage, 1)
+        cv.imwrite("marker23.jpg", markerImage)
+        return True
+    else:
+        return False
+
+
+def extract_panel_bounds(image):
+    """
+    Extracts the top-left, bottom-right coordinates of a rectangular raster at the center 
+    of the reflective panel 
+    :param image: The numpy array of the image
+    :return: list of an x,y tuple of top-left and bottom-right pixels
+    """
+    # o------>  +X
+    # |
+    # |
+    # v +Y
+    dictionary = cv.aruco.Dictionary_get(cv.aruco.DICT_6X6_250)
+    
+    corners, ids, rejectedImgPoints	= cv.aruco.detectMarkers(image, dictionary)
+    # if at least one marker detected
+    if (not ids is None):
+        aruco_side_length_p = cv.norm(corners[0][0][1] - corners[0][0][0])
+        gsd = ARUCO_SIDE_LENGTH_M / aruco_side_length_p
+        print(f"GSD: {gsd:10.5f} m/pixel")
+
+        top_aruco_line = corners[0][0][0] - corners[0][0][3]
+        top_aruco_line_middle = top_aruco_line / 2.0 + corners[0][0][3]
+        
+        top_aruco_line_normal = np.array([top_aruco_line[1], -top_aruco_line[0]])
+
+        top_aruco_line_normal /= cv.norm(top_aruco_line_normal)
+        top_aruco_line_normal_scaled_pixels = (ARUCO_TOP_TO_PANEL_CENTER_M / gsd) * top_aruco_line_normal
+
+        sample_center = top_aruco_line_middle + top_aruco_line_normal_scaled_pixels
+        sample_top_left_corner = np.array([sample_center[0] - (SAMPLE_RECT_HEIGHT / 2.0) / gsd, sample_center[1] - (SAMPLE_RECT_WIDTH / 2.0) / gsd])
+
+        top_left_x = int(sample_top_left_corner[0])
+        top_left_y = int(sample_top_left_corner[1])
+        bottom_right_x = top_left_x + int(sample_top_left_corner[0] + SAMPLE_RECT_WIDTH / gsd)
+        bottom_right_y = top_left_y + int(sample_top_left_corner[1] + SAMPLE_RECT_HEIGHT / gsd)
+
+        rectangle_position = [(top_left_x, top_left_y),
+                              (bottom_right_x, bottom_right_y)]
+        
+        return rectangle_position      
+    return None
+
+
+def get_mean_reflectance_list(image_folder):
+    """
+    Detects pixels in the reflectance panel and decides on the best image to use for calibration
+    :param image_folder: The path to the folder with the calibration images
+    :return: A list of the average values of the reflectance panel for every valid calibration image
+    """
+    reflectance_array = []
+    image_files = glob.glob(image_folder + '/*.tif')
+    for image_file in image_files:
+        # Read the original (12-bit) tiff with the next largest commonly used container (16-bit)
+        image_16bit = np.asarray(Image.open(image_file)).astype(np.uint16)
+        # OpenCV aruco detection only accepts 8-bit data
+        image_8bit = convert_to_type(image_16bit, np.uint8)
+        rectangle_position = extract_panel_bounds(image_8bit)
+        if rectangle_position is None:
+            continue
+
+        # Visualize the rectangle for verification purposes
+        # image_copy = image_8bit.copy()
+        # x_start = rectangle_position[0][0]
+        # y_start = rectangle_position[0][1]
+        # x_end = rectangle_position[1][0]
+        # y_end = rectangle_position[1][1]
+        # image_copy = cv.rectangle(image_copy,(x_start, y_start),(x_end, y_end),(0,255,0),3)
+        # cv.imwrite("res"+str(np.random.rand())+".jpg", image_copy)
+
+        reflectance_pixels = image_16bit[rectangle_position[0][0]:rectangle_position[1][0],
+                                         rectangle_position[0][1]:rectangle_position[1][1]]
+        mean_reflectance_digital_number = reflectance_pixels.mean()
+        print(f"Mean DN: {mean_reflectance_digital_number:10.5}")
+
+        reflectance_array.append(mean_reflectance_digital_number)
+
+    return reflectance_array
+        

--- a/scripts/correct_ils_6x_images.py
+++ b/scripts/correct_ils_6x_images.py
@@ -187,7 +187,7 @@ def move_corrected_images(image_df):
     image_df.apply(lambda row: _move_images(row), axis=1)
 
 
-def correct_6x_images(input_path, output_path, no_ils_correct, delete_original, exiftool_path):
+def correct_ils_6x_images(input_path, output_path, no_ils_correct, delete_original, exiftool_path):
 
     def _flag_format(flag):
         if flag:
@@ -239,4 +239,4 @@ if __name__ == '__main__':
                              "raised.")
 
     args = parser.parse_args()
-    correct_6x_images(**vars(args))
+    correct_ils_6x_images(**vars(args))

--- a/scripts/correct_reflectance_6x_images.py
+++ b/scripts/correct_reflectance_6x_images.py
@@ -1,0 +1,27 @@
+import argparse
+import logging
+
+from corrections import detect_panel
+
+
+def correct_reflectace_6x_images(input_calibration_path, input_images_path, output_path):
+    mean_dn_list = detect_panel.get_mean_reflectance_list(input_calibration_path)
+    print(f"Mean list {mean_dn_list}")
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--input_calibration_path', '-c',
+                        help='Path to folder with CAL_* images, taken from a Sentera 6X sensor.')
+    parser.add_argument('--input_images_path', '-i',
+                        help='Path to folder where the 6X sensor images are stored.')
+    parser.add_argument('--output_path', '-o', default=None,
+                        help='Path to output folder at which the corrected images will be stored. If not supplied, '
+                             'corrected images will be placed into the input directory.')
+
+    args = parser.parse_args()
+
+    correct_reflectace_6x_images(**vars(args))
+    

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
         "tifffile",
         "pandas",
         "tqdm",
+        "opencv-contrib-python"
     ],
     extras_require={
         "dev": ["pytest", "sphinx_rtd_theme", "pre-commit", "m2r", "sphinx"],


### PR DESCRIPTION
Add support for reflectance panel calibration.

This feature accepts the folder that holds the calibration images and returns a list of average pixel values from all the images where the aruco marker has been detected.