### PR TITLE
Fix GHA tag generation function to use main branch instead of master

### DIFF
--- a/.github/workflows/main-branch.yaml
+++ b/.github/workflows/main-branch.yaml
@@ -3,7 +3,7 @@ name: Create GitHub Release
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Fix GHA tag generation function to use main branch instead of master
## What?
## Why?
## PR Checklist
- [ ] Merged latest master
- [ ] Updated version number
- [ ] Version numbers match between package ``__version__`` and *pyproject.toml*
- [ ] All private git packages are at their newest version in both *pyproject.toml* and *environment.yml*
- [ ] All git package version numbers match between *pyproject.toml* and *environment.yml*
- [ ] dist/ImageryCorrector.exe and dist/GetCorrectionsCsv.exe have been rebuilt
## Breaking Changes