### PR TITLE
Raise clear error when no flight images present for ILS correction

### DIFF
--- a/imgcorrect/corrections.py
+++ b/imgcorrect/corrections.py
@@ -168,6 +168,12 @@ def compute_reflectance_correction(
     )
 
     if ils_present:
+        if image_df.empty:
+            raise FileNotFoundError(
+                "ILS correction requires non-calibration images to compute the average "
+                "scene ILS, but none were found in the input path. Either include flight "
+                "images alongside the calibration panel images, or disable ILS Correction."
+            )
         band_avg_ils = image_df.groupby("band").ILS.mean().reset_index()
         band_df["ils_scaling_factor"] = band_df.merge(band_avg_ils, on="band").apply(
             _get_ils_scaling, axis=1


### PR DESCRIPTION
Add error handling for empty image DataFrame in ILS correction.

## What?
Raises an explicit `FileNotFoundError` when `image_df` is empty after the calibration/non-calibration split in `io.create_cal_df`, before reaching the ILS merge step.

## Why?
If `ils_present=True` and the Input Path contains only calibration panel images (no flight images), `image_df` ends up empty after the split. The subsequent merge with `band_avg_ils` produces 0 rows, and `DataFrame.apply(axis=1)` on that empty, multi-column frame returns the original DataFrame instead of an empty Series — causing `band_df["ils_scaling_factor"] = ...` to fail with a confusing internal pandas error instead of a clear, actionable message.

Full reproduction and root-cause writeup: Closes #77

## PR Checklist
- [ ] Merged latest master
- [ ] Updated version number
- [ ] All private git packages are at their newest version in both *pyproject.toml* and *environment.yml*
- [ ] All git package version numbers match between *pyproject.toml* and *environment.yml*
- [ ] dist/ImageryCorrector.exe and dist/GetCorrectionsCsv.exe have been rebuilt

## Breaking Changes
None. This only adds a new, earlier validation error for an input configuration that previously failed anyway, just with a less clear message.